### PR TITLE
fix: it does not give an error message when a space is entered in the description

### DIFF
--- a/src/pages/assignments/Actions/CreateAssignment.tsx
+++ b/src/pages/assignments/Actions/CreateAssignment.tsx
@@ -148,7 +148,12 @@ export default function CreateAssignment({ formProps, drawerProps, saveButtonPro
               },
             ]}
           >
-            <Input />
+            <Input
+              onChange={(e) => {
+                const value = e.target.value.replace("  ", " ");
+                form.setFieldValue("description", value);
+              }}
+            />
           </Form.Item>
           <Form.Item
             style={{ marginBottom: 8 }}

--- a/src/pages/assignments/Actions/EditAssignment.tsx
+++ b/src/pages/assignments/Actions/EditAssignment.tsx
@@ -164,7 +164,12 @@ export default function EditAssignment({
               },
             ]}
           >
-            <Input />
+            <Input
+              onChange={(e) => {
+                const value = e.target.value.replace("  ", " ");
+                form.setFieldValue("description", value);
+              }}
+            />
           </Form.Item>
           <Form.Item
             style={{ marginBottom: 8 }}


### PR DESCRIPTION

# Pull Request

## Description

Fix: it does not give an error message when a space is entered in the description

## Issue

closes #96 

## Changes Made

- [ ] Feature added
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please specify)

## Screenshots (if applicable)

![image](https://github.com/afet-yonetim-sistemi/ays-fe-institution/assets/109898313/812a8f8d-2f91-4f9d-9137-b3087f95309b)

## Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I have followed the [code style guidelines](../CONTRIBUTING.md#code-of-conduct).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the [license](LICENSE.md).
- [x] I have updated the documentation accordingly.
- [ ] I have assigned relevant reviewers to this pull request.
- [ ] I have responded to any reviewer comments in a timely manner.
- [x] I have checked that no similar pull requests exist.

## Reviewers
 
@rasitcolakel @kevseroz @aydogansar @WizardLizard8998 
