### PR TITLE
AYS-248 | add missing comma in i18next JSON file

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -39,7 +39,7 @@
   "desc": "Click to sort descending",
   "asc": "Click to sort ascending",
   "invalidEmailAndPassword": "Invalid E-mail or Password.",
-  "defaultError": "An error occurred. Please try again later."
+  "defaultError": "An error occurred. Please try again later.",
   "invalidEmailAndPassword": "Invalid E-mail or Password.",
   "defaultError": "An error occurred. Please try again later.",
   "invalidEmail": "Invalid E-mail."

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -39,6 +39,6 @@
   "defaultError": "Bir hata oluştu. Lütfen tekrar deneyin.",
   "invalidEmail": "Geçersiz e-posta adresi.",
   "desc": "Azalan sıraya göre sıralamak için tıklayın",
-  "asc": "Artan sıraya göre sıralamak için tıklayın"
+  "asc": "Artan sıraya göre sıralamak için tıklayın",
   "invalidEmail": "Geçersiz e-posta adresi."
 }


### PR DESCRIPTION
This pull request resolves a parsing error in the i18next JSON file due to a missing comma. The missing comma has been added, ensuring proper JSON format and preventing future errors.

Changes:
- Added the missing comma in the relevant "i18n/locales/en.json" &  "i18n/locales/tr.json" JSON files.
