### PR TITLE
Bugfix: AYS-519 | Updated PhoneInput to handle value prop for countryCode and lineNumber

### DIFF
--- a/src/app/(public)/register-completion/[id]/page.tsx
+++ b/src/app/(public)/register-completion/[id]/page.tsx
@@ -168,7 +168,17 @@ const Page = ({
                     <FormItem>
                       <FormLabel>{t('phoneNumber')}</FormLabel>
                       <FormControl>
-                        <PhoneInput onChange={field.onChange} />
+                        <PhoneInput
+                          onChange={field.onChange}
+                          value={
+                            field.value as unknown as
+                              | ((string & { __tag: 'E164Number' }) & {
+                                  countryCode: string
+                                  lineNumber: string
+                                })
+                              | undefined
+                          }
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -28,12 +28,16 @@ type PhoneInputProps = Omit<
 > &
   Omit<RPNInput.Props<typeof RPNInput.default>, 'onChange'> & {
     onChange?: (value: unknown) => void
+    value: { countryCode: string; lineNumber: string } | undefined
     disableCountrySelection?: boolean
   }
 
 const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
   React.forwardRef<React.ElementRef<typeof RPNInput.default>, PhoneInputProps>(
-    ({ className, onChange, disableCountrySelection, ...props }, ref) => {
+    (
+      { className, onChange, value, disableCountrySelection, ...props },
+      ref
+    ) => {
       const handleChange = (value: string | undefined): void => {
         if (!value) {
           onChange?.({ countryCode: '', lineNumber: '' })
@@ -61,6 +65,7 @@ const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
           )}
           inputComponent={InputComponent}
           onChange={handleChange}
+          value={value ? `+${value.countryCode}${value.lineNumber}` : undefined}
           defaultCountry="TR"
           {...props}
         />


### PR DESCRIPTION
This pull request includes changes to improve the handling of phone number input in the registration completion page. The most important changes include updating the `PhoneInput` component to handle a more structured value format and modifying the usage of `PhoneInput` to accommodate these changes.

Improvements to phone number input handling:

* `src/app/(public)/register-completion/[id]/page.tsx`: Updated the `PhoneInput` component to accept a structured value format, including `countryCode` and `lineNumber`.
* [`src/components/ui/phone-input.tsx`](diffhunk://#diff-0e8801054590e7c3a20739a7be8800232ed77b40206cfacef1eba1f9819cb904R31-R40): Added a `value` prop to the `PhoneInputProps` type, which includes `countryCode` and `lineNumber`.
* [`src/components/ui/phone-input.tsx`](diffhunk://#diff-0e8801054590e7c3a20739a7be8800232ed77b40206cfacef1eba1f9819cb904R68): Modified the `PhoneInput` component to use the new `value` prop format and correctly concatenate `countryCode` and `lineNumber` for display.